### PR TITLE
#161148121 API endpoint to Fetch all accounts of a team

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -109,6 +109,19 @@ function updateFavoriteAttributes(favorite) {
 }
 
 /**
+ * @method updateAccountAttributes
+ * @desc Return updated account details
+ *
+ * @param { object } account the input account object
+ *
+ * @returns { object } the output account object
+ */
+function updateAccountAttributes(account) {
+  account = account.get();
+  return account;
+}
+
+/**
  * @method updateMembershipAttributes
  * @desc Return updated membership details
  *
@@ -217,6 +230,7 @@ export default {
     updateFavoriteAttributes,
     updateMembershipAttributes,
     updateTeamAttributes,
-    updateUserAttributes
+    updateUserAttributes,
+    updateAccountAttributes
   }
 };

--- a/src/routes/teamAccounts.js
+++ b/src/routes/teamAccounts.js
@@ -35,6 +35,33 @@ routes.get(
   membersController.getById
 );
 */
+
+/**
+   * @swagger
+   * /v1/teams/:teamId/accounts:
+   *   get:
+   *     description: Return the all the account
+   *     with the specified team id
+   *     produces:
+   *      - application/json
+   *     responses:
+   *       200:
+   *         description: teamAccounts
+   *         schema:
+   *           type: object
+   *           items:
+   *             $ref: '#/definitions/ResponseBody'
+   */
+routes.get(
+  '/:teamId/accounts',
+  middleware.check.teamWithParamsIdExists,
+  middleware.pagination,
+  middleware.search,
+  middleware.sort,
+  middleware.filter,
+  accountsController.get
+);
+
 routes.post(
   '/:teamId/accounts',
   middleware.check.teamWithParamsIdExists,

--- a/test/endpoints/teams.accounts.spec.js
+++ b/test/endpoints/teams.accounts.spec.js
@@ -1,3 +1,4 @@
+/* eslint no-unused-expressions:0 */
 /**
  * @fileOverview Tests for /v1/teams/:teamId/accounts
  *
@@ -355,5 +356,56 @@ describe('Tests for /v1/teams/:teamId/accounts', () => {
           });
       }
     );
+  });
+  describe('GET: /v1/teams/:teamId/accounts', (done) => {
+    it(
+      'should not get a team account with invalid team ID',
+      (done) => {
+        const teamId = '7a2a5d4e-80b4-411a-8d79-0759b6ab06b0';
+        chai.request(server)
+          .get(`/v1/teams/${teamId}/accounts`)
+          .set('x-teams-user-token', mock.user0.token)
+          .end((err2, res) => {
+            res.should.have.status(200);
+            expect(res.body.errors)
+              .to.include('Team with the specified ID does not exist.');
+            expect(res.body.data).to.be.undefined;
+
+            done();
+          });
+      }
+    );
+    it('should get all team accounts', (done) => {
+      chai.request(server)
+        .post('/v1/teams')
+        .send(mock.team1)
+        .set('x-teams-user-token', mock.user0.token)
+        .end((err, res) => {
+          team1 = res.body.data.team;
+
+          chai.request(server)
+            .post(`/v1/teams/${team1.id}/accounts`)
+            .send(mock.account1)
+            .set('x-teams-user-token', mock.user0.token)
+            .end((err, res2) => {
+              // Get team accounts
+              chai.request(server)
+                .get(`/v1/teams/${team1.id}/accounts`)
+                .set('x-teams-user-token', mock.user0.token)
+                .end((err, res3) => {
+                  res3.should.have.status(200);
+                  res3.body.should.have.property('data');
+                  expect(res3.body.data).to.be.an('Object');
+                  res3.body.data.should.have.property('accounts');
+                  expect(res3.body.data.accounts.length).to.equal(1);
+                  expect(res3.body.data.accounts[0].id).to.not.be.undefined;
+                  expect(res3.body.data.accounts[0].teamId).to.equal(team1.id);
+                  expect(res3.body.data.accounts[0].url).to.not.be.undefined;
+                  expect(res3.body.errors).to.be.undefined;
+                  done();
+                });
+            });
+        });
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- Gets all accounts that a particular team has
#### Description of Task to be completed?
 - Added a method that gets all team account in the account controller
- Added an API route that gets all accounts of a team
#### How should this be manually tested?
 - Clone this repo
- yarn install
- Add necessary env variable as specified in .env.sample
- yarn test
#### Any background context you want to provide?
- This API enables a user to get the accounts of  a team
#### What are the relevant pivotal tracker stories?
[#16114812](https://www.pivotaltracker.com/story/show/161148121)
#### Screenshots (if appropriate)
N/A
#### Questions:
